### PR TITLE
chore: add agent instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,43 @@
+# GitHub Copilot — instrucciones breves para este repo
+
+Propósito: ayudar a agentes automatizados o asistentes en PRs a entender lo esencial rápidamente.
+
+Resumen rápido
+- Proyecto: página personal + blog (multilingüe: inglés y español).
+- Deploy: Netlify (configuración en `netlify.toml`, publica `dist/`).
+
+Comandos útiles
+- `npm install` — instalar dependencias.
+- `npm run dev` — servidor de desarrollo (Astro).
+- `npm run build` — construir sitio estático en `dist/`.
+- `npm run preview` — previsualizar build localmente.
+- `npm run lint` y `npm run check` — lint y validaciones de contenido/TypeScript.
+- `npm run ci` — tarea CI combinada (lint + check + build).
+
+Dónde editar contenido
+- Posts EN: `src/content/blog/en/`
+- Posts ES: `src/content/blog/es/`
+- Páginas (estáticas): `src/content/pages/en/` y `src/content/pages/es/`
+- Rutas dinámicas: `src/pages/[...slug].astro`
+- Esquema y validaciones: `src/content.config.ts` (Zod)
+
+Convenciones importantes
+- Idioma por defecto: inglés (sin prefijo); español en `/es/`.
+- No eliminar ni renombrar claves de frontmatter requeridas por `src/content.config.ts`.
+- Evitar refactors a gran escala sin abrir un issue/PR explicando el motivo.
+- Antes de subir PRs que cambien componentes o estilos, ejecutar `npm run lint` y `npm run check` y verificar `npm run build`.
+
+Notas de despliegue y entorno
+- Netlify usa `npm run build` y publica `dist/` (ver `netlify.toml`).
+- Revisar `engines` en `package.json` para la versión mínima de Node/NPM.
+
+Referencias rápidas
+- Orientación ampliada para agentes: [AGENTS.md](AGENTS.md)
+- Configuración del proyecto: [package.json](package.json), [astro.config.mjs](astro.config.mjs)
+
+Checklist mínima para PRs
+1. Ejecutar `npm run lint` y `npm run check`.
+2. Si el cambio afecta contenido, validar frontmatter y traducciones.
+3. Ejecutar `npm run build` localmente para detectar errores de compilación.
+
+Si quieres, puedo ajustar esto para añadir instrucciones de commit/PR automáticas o un skill que valide sincronía de traducciones.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md — AI agent quick orientation
+
+Purpose: give AI coding agents the minimal, actionable knowledge they need to be productive in this repository.
+
+Quick commands
+- Install: `npm install` — see [package.json](package.json) for engines and scripts.
+- Dev: `npm run dev` — local dev server (Astro).
+- Build: `npm run build` — produces `dist/` (used by Netlify).
+- Lint / checks: `npm run lint`, `npm run check`, `npm run format:check`.
+
+Key files & locations (link, don't embed)
+- Project manifest: [package.json](package.json)
+- Astro config / integrations: [astro.config.mjs](astro.config.mjs)
+- Deployment: [netlify.toml](netlify.toml)
+- Content schema & collections: [src/content.config.ts](src/content.config.ts)
+- Pages / routes: [src/pages/](src/pages/)
+- Components (Vue + Astro): [src/components/](src/components/)
+- Layouts: [src/layouts/](src/layouts/)
+- Styles (Spectre + theme): [src/styles/](src/styles/)
+- Types: [src/types/](src/types/)
+
+Important conventions & notes
+- Frameworks: Astro + Vue 3. Prefer small scoped changes to components; respect existing component APIs.
+- i18n: English is default (no prefix); Spanish lives under `/es/`. See [astro.config.mjs](astro.config.mjs).
+- Content: blog and pages live under `src/content/` with `en/` and `es/` folders. Content schema validated in [src/content.config.ts](src/content.config.ts).
+- Node: project expects modern Node (see `engines` in [package.json](package.json)); tests/builds may fail on older runtimes.
+- Build output: static `dist/` directory. Netlify deploy uses `npm run build` and publishes `dist/`.
+
+Agent behavior guidelines (short)
+- Link to, don't copy, large docs; prefer pointers to canonical files above.
+- Avoid wide-scope refactors without user approval; open a PR description first.
+- When editing content, preserve frontmatter keys required by `src/content.config.ts`.
+- Run `npm run lint` and `npm run check` locally before proposing CI fixes.
+
+Suggested next agent customizations
+- `create-skill:content-sync` — automate cross-locale content sync checks and missing translation reports.
+- `create-instruction:deploy` — a small `.github/copilot-instructions.md` with deploy steps and Netlify caveats.
+
+If you'd like, I can also create a `.github/copilot-instructions.md` that surfaces the short commands above for GitHub-based agents.


### PR DESCRIPTION
Adds AGENTS.md and .github/copilot-instructions.md to help AI agents be productive. Includes quick commands, content locations (blog EN/ES), i18n notes, and a PR checklist.\n\nFiles: AGENTS.md, .github/copilot-instructions.md