### PR TITLE
Fix/optional og image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@astrojs/vue": "^6.0.1",
         "@iconify-icons/mdi": "^1.2.48",
         "@iconify/vue": "^4.3.0",
+        "@resvg/resvg-js": "^2.6.2",
         "ackee-tracker": "^5.1.3",
         "astro": "^6.1.8",
         "sass": "^1.99.0",
@@ -32,7 +33,7 @@
         "vue-eslint-parser": "^10.4.0"
       },
       "engines": {
-        "node": ">=22.13.0",
+        "node": ">=22.12.0",
         "npm": ">=10.8.2"
       }
     },
@@ -2204,6 +2205,221 @@
       "version": "1.0.0-next.29",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="
+    },
+    "node_modules/@resvg/resvg-js": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.13",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@astrojs/vue": "^6.0.1",
     "@iconify-icons/mdi": "^1.2.48",
     "@iconify/vue": "^4.3.0",
+    "@resvg/resvg-js": "^2.6.2",
     "ackee-tracker": "^5.1.3",
     "astro": "^6.1.8",
     "sass": "^1.99.0",

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -4,13 +4,13 @@ import { SITE_METADATA } from "../const/site";
 const {
   title,
   description,
-  image = "/icons/favicon-32x32.png",
+  image,
   hreflang,
   structuredData,
 } = Astro.props;
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site ?? Astro.url);
-const absoluteImage = new URL(image, Astro.site ?? Astro.url);
+const absoluteImage = image ? new URL(image, Astro.site ?? Astro.url).toString() : undefined;
 const defaultStructuredData = {
   "@context": "https://schema.org",
   "@type": "WebSite",
@@ -70,14 +70,14 @@ interface Props {
 <meta property="og:url" content={canonicalURL} />
 <meta property="og:title" content={title} />
 <meta property="og:description" content={description} />
-<meta property="og:image" content={absoluteImage} />
+{absoluteImage && <meta property="og:image" content={absoluteImage} />}
 
 <!-- Twitter -->
-<meta property="twitter:card" content="summary_large_image" />
+<meta property="twitter:card" content="summary" />
 <meta property="twitter:url" content={canonicalURL} />
 <meta property="twitter:title" content={title} />
 <meta property="twitter:description" content={description} />
-<meta property="twitter:image" content={absoluteImage} />
+{absoluteImage && <meta property="twitter:image" content={absoluteImage} />}
 
 <!-- hreflang -->
 {

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -73,7 +73,10 @@ interface Props {
 {absoluteImage && <meta property="og:image" content={absoluteImage} />}
 
 <!-- Twitter -->
-<meta property="twitter:card" content="summary" />
+<meta
+  property="twitter:card"
+  content={absoluteImage ? "summary_large_image" : "summary"}
+/>
 <meta property="twitter:url" content={canonicalURL} />
 <meta property="twitter:title" content={title} />
 <meta property="twitter:description" content={description} />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -10,6 +10,7 @@ interface Props {
   bodyClass?: string;
   title?: string;
   description?: string;
+  image?: string;
   structuredData?: Record<string, unknown> | Array<Record<string, unknown>>;
   hreflang?: Array<{
     lang: string;
@@ -21,7 +22,7 @@ const {
   bodyClass = "header-dark header-transparent header-fixed header-animated",
 } = Astro.props;
 
-const { title, description, hreflang, structuredData } = Astro.props;
+const { title, description, image, hreflang, structuredData } = Astro.props;
 
 const ackeeData = {
   domain: import.meta.env.PUBLIC_ACKEE_DOMAIN,
@@ -40,6 +41,7 @@ const ackeeData = {
     <Head
       title={`${title} | ${SITE_METADATA.siteTitle}`}
       description={description ? description : SITE_METADATA.siteDescription}
+      image={image}
       hreflang={hreflang}
       structuredData={structuredData}
     />

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -85,6 +85,9 @@ const alternateLanguage = normalizedHreflang.find(
   (item) => item.lang !== page.lang,
 );
 
+const isBlogPost = page.collection === "blog";
+const socialImage = page.data.image ?? (isBlogPost ? `/og/${page.slug}.png` : undefined);
+
 const hreflang = [
   {
     lang: page.lang,
@@ -114,8 +117,8 @@ const structuredData =
           Astro.url.pathname,
           Astro.site ?? Astro.url,
         ).toString(),
-        ...(page.data.image && {
-          image: new URL(page.data.image, Astro.site ?? Astro.url).toString(),
+        ...(socialImage && {
+          image: new URL(socialImage, Astro.site ?? Astro.url).toString(),
         }),
         author: {
           "@type": "Person",
@@ -125,12 +128,12 @@ const structuredData =
       }
     : undefined;
 
-const isBlogPost = page.collection === "blog";
 ---
 
 <Layout
   title={title}
   description={page.data.description}
+  image={socialImage}
   bodyClass={bodyClasses}
   hreflang={hreflang}
   structuredData={structuredData}

--- a/src/pages/og/[...slug].png.ts
+++ b/src/pages/og/[...slug].png.ts
@@ -1,0 +1,187 @@
+import { Resvg } from "@resvg/resvg-js";
+import { getCollection } from "astro:content";
+
+const WIDTH = 1200;
+const HEIGHT = 630;
+const PADDING_X = 90;
+const TEXT_WIDTH = 1020;
+
+function normalizeIdToSlug(id: string) {
+  return id.replace(/\.mdx?$/, "");
+}
+
+function wrapText(text: string, maxLength: number) {
+  const words = text.split(/\s+/).filter(Boolean);
+  const lines: string[] = [];
+  let currentLine = "";
+
+  for (const word of words) {
+    const candidate = currentLine ? `${currentLine} ${word}` : word;
+
+    if (candidate.length <= maxLength) {
+      currentLine = candidate;
+      continue;
+    }
+
+    if (currentLine) {
+      lines.push(currentLine);
+    }
+
+    currentLine = word;
+  }
+
+  if (currentLine) {
+    lines.push(currentLine);
+  }
+
+  return lines;
+}
+
+function escapeXml(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function renderLines(
+  text: string,
+  x: number,
+  y: number,
+  maxLength: number,
+  lineHeight: number,
+  className: string,
+  maxLines?: number,
+) {
+  const lines = wrapText(text, maxLength).slice(0, maxLines ?? Infinity);
+
+  return `
+    <text x="${x}" y="${y}" class="${className}">
+      ${lines
+        .map((line, index) => `<tspan x="${x}" dy="${index === 0 ? 0 : lineHeight}">${escapeXml(line)}</tspan>`)
+        .join("")}
+    </text>
+  `;
+}
+
+export async function getStaticPaths() {
+  const posts = (await getCollection("blog"))
+    .filter((post) => post.data.published)
+    .sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime());
+
+  return posts.map((post) => {
+    const normalizedId = normalizeIdToSlug(post.id);
+
+    return {
+      params: {
+        slug: normalizedId.startsWith("en/")
+          ? normalizedId.slice(3)
+          : normalizedId,
+      },
+      props: {
+        post: {
+          ...post,
+          slug: normalizedId.startsWith("en/")
+            ? normalizedId.slice(3)
+            : normalizedId,
+          lang: normalizedId.startsWith("en/") ? "en" : "es",
+        },
+      },
+    };
+  });
+}
+
+export async function GET({ props }: { props: { post: any } }) {
+  const { post } = props;
+  const title = post.data.subtitle
+    ? `${post.data.title}: ${post.data.subtitle}`
+    : post.data.title;
+  const description = post.data.description ?? "";
+  const date = new Date(post.data.date).toLocaleDateString("en", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+  const tags: string[] = Array.isArray(post.data.taxonomy?.tag)
+    ? post.data.taxonomy.tag.slice(0, 3)
+    : [];
+
+  const svg = `
+    <svg width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
+          <stop stop-color="#f6f1e8" />
+          <stop offset="1" stop-color="#eadfd0" />
+        </linearGradient>
+        <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0" stop-color="#0f172a" stop-opacity="0.16" />
+          <stop offset="1" stop-color="#0f172a" stop-opacity="0.03" />
+        </linearGradient>
+        <pattern id="dots" width="28" height="28" patternUnits="userSpaceOnUse">
+          <circle cx="3" cy="3" r="1.2" fill="#0f172a" fill-opacity="0.08" />
+        </pattern>
+      </defs>
+      <rect width="1200" height="630" rx="36" fill="url(#bg)" />
+      <rect x="0" y="0" width="1200" height="630" rx="36" fill="url(#dots)" />
+      <circle cx="1040" cy="120" r="150" fill="#d9c7af" fill-opacity="0.35" />
+      <circle cx="1030" cy="120" r="96" fill="#f4ede1" fill-opacity="0.9" />
+      <rect x="70" y="70" width="220" height="54" rx="27" fill="#0f172a" fill-opacity="0.9" />
+      <text x="102" y="105" fill="#f8fafc" font-size="24" font-family="IBM Plex Mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" letter-spacing="0.08em">BLOG POST</text>
+      <rect x="${PADDING_X}" y="155" width="${TEXT_WIDTH}" height="6" rx="3" fill="#0f172a" fill-opacity="0.15" />
+      <text x="${PADDING_X}" y="200" fill="#0f172a" font-size="26" font-family="IBM Plex Mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" letter-spacing="0.04em">rubenr.dev</text>
+      ${renderLines(title, PADDING_X, 270, 30, 58, "title-text", 3)}
+      ${description ? renderLines(description, PADDING_X, 470, 54, 40, "desc-text", 3) : ""}
+      <text x="${PADDING_X}" y="548" fill="#0f172a" font-size="22" font-family="Space Grotesk, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif" opacity="0.78">${escapeXml(date)}</text>
+      <rect x="${PADDING_X}" y="565" width="180" height="2" rx="1" fill="#0f172a" fill-opacity="0.18" />
+      ${
+        tags.length
+          ? `
+            <g transform="translate(${PADDING_X}, 582)">
+              ${tags
+                .map(
+                  (tag: string, index: number) => `
+                    <g transform="translate(${index * 132}, 0)">
+                      <rect x="0" y="0" width="120" height="34" rx="17" fill="#fff" fill-opacity="0.72" stroke="#0f172a" stroke-opacity="0.08" />
+                      <text x="60" y="23" text-anchor="middle" fill="#0f172a" font-size="18" font-family="IBM Plex Mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace">${escapeXml(tag)}</text>
+                    </g>
+                  `,
+                )
+                .join("")}
+            </g>
+          `
+          : ""
+      }
+      <style>
+        .title-text {
+          fill: #0f172a;
+          font-family: Fraunces, Georgia, serif;
+          font-size: 68px;
+          font-weight: 700;
+          letter-spacing: -0.04em;
+        }
+        .desc-text {
+          fill: #334155;
+          font-family: Space Grotesk, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+          font-size: 28px;
+          font-weight: 400;
+        }
+      </style>
+    </svg>
+  `;
+
+  const png = new Resvg(svg, {
+    fitTo: {
+      mode: "width",
+      value: WIDTH,
+    },
+  }).render().asPng();
+
+  return new Response(new Uint8Array(png), {
+    headers: {
+      "Content-Type": "image/png",
+      "Cache-Control": "public, max-age=0, s-maxage=31536000, immutable",
+    },
+  });
+}


### PR DESCRIPTION
This pull request introduces dynamic Open Graph (OG) image generation for blog posts and improves how social sharing metadata is handled throughout the site. The main changes include adding a new endpoint for generating OG images, updating metadata logic to use these images for blog posts, and making the social meta tags more robust and conditional.

**Dynamic OG image generation:**

* Added a new dynamic route `src/pages/og/[...slug].png.ts` that generates OG images for blog posts using SVG and the `@resvg/resvg-js` library. The generated images include the post title, description, date, and tags, and are customized per post. ([src/pages/og/[...slug].png.tsR1-R187](diffhunk://#diff-a05664313cd53637e5aea0ac30a34aec5b3ced1c636bbdacbfc3e7ffef58a802R1-R187), [package.jsonR48](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R48))

**Social metadata improvements:**

* Updated the logic in `src/pages/[...slug].astro` to set the `image` property for social sharing: blog posts now use the dynamically generated OG image, while other pages fall back to existing logic. This value is also used in structured data. ([src/pages/[...slug].astroR88-R90](diffhunk://#diff-3e5acaf836c0d971d776116150de3383139f854ab2dca0058094287f0113e85bR88-R90), [src/pages/[...slug].astroL117-R121](diffhunk://#diff-3e5acaf836c0d971d776116150de3383139f854ab2dca0058094287f0113e85bL117-R121), [src/pages/[...slug].astroL128-R136](diffhunk://#diff-3e5acaf836c0d971d776116150de3383139f854ab2dca0058094287f0113e85bL128-R136))
* Modified the `Layout` and `Head` components to accept and propagate the new `image` prop, ensuring that social meta tags use the correct image. [[1]](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2R13) [[2]](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2L24-R25) [[3]](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2R44) [[4]](diffhunk://#diff-a1e92208f865df9873b46986ec1a34de409d38bc50779c9d719cd8f580c56044L7-R13)
* Improved the rendering of OG and Twitter meta tags in `Head.astro` to only include image tags when an image is present, and to set the Twitter card type accordingly.