### PR TITLE
Update uses and about pages with current tools and skills

### DIFF
--- a/src/const/about.ts
+++ b/src/const/about.ts
@@ -36,16 +36,20 @@ export const RESUME = [
             icon: "vscode-icons:file-type-vue",
           },
           {
-            name: "React",
-            icon: "vscode-icons:file-type-reactjs",
+            name: "Astro",
+            icon: "vscode-icons:file-type-astro",
+          },
+          {
+            name: "Svelte",
+            icon: "vscode-icons:file-type-svelte",
           },
           {
             name: "Jest",
             icon: "vscode-icons:file-type-jest",
           },
           {
-            name: "Cypress",
-            icon: "vscode-icons:file-type-cypress",
+            name: "Playwright",
+            icon: "vscode-icons:file-type-playwright",
           },
         ],
       },

--- a/src/content/pages/en/uses.md
+++ b/src/content/pages/en/uses.md
@@ -11,11 +11,11 @@ description: "Here a small list of software and hardware that I use."
 - **External Display**: Dell U2414H
 - **Keyboard**: Keychron K6 Pro
 - **Mouse**: Logitech MX Master 3
-- **Headphones**: Sennheiser Hd-25 || Huawei FreeBuds Pro
+- **Headphones**: Sennheiser Hd-25 || AirPods Pro 3
 
 ## 📀 Software
 
-- **Editor**: [VS Code](https://code.visualstudio.com) with One Dark Theme
+- **Editor**: [VS Code](https://code.visualstudio.com) and [Cursor](https://cursor.com) with One Dark Theme
 - **Terminal**: [iTerm](http://iterm2.com/) with [Oh My Zsh](https://github.com/ohmyzsh/ohmyzsh)
 - **Font**: [Fira Code Retina](https://www.google.com/search?client=safari&rls=en&q=Fira+Code+Retina&ie=UTF-8&oe=UTF-8)
 - **Browser**: [Brave](https://brave.com/)


### PR DESCRIPTION
## Summary
- Update the uses page: replace FreeBuds with AirPods Pro 3, and list VS Code and Cursor as editors.
- Update the about page skills: replace React and Cypress with Astro, Svelte, and Playwright.

## Test plan
- [ ] Visit `/uses` and verify headphones and editor entries
- [ ] Visit `/about` and verify the skills section shows Astro, Svelte, and Playwright (no React or Cypress)

Made with [Cursor](https://cursor.com)